### PR TITLE
Added copy functionality

### DIFF
--- a/src/components/DetailSection.tsx
+++ b/src/components/DetailSection.tsx
@@ -1,7 +1,8 @@
 import { ChevronRightIcon, HStack, Spacer, VStack } from 'native-base'
 import React from 'react'
-import { ColorValue, TouchableOpacity, TouchableOpacityProps } from 'react-native'
+import { ColorValue, Platform, ToastAndroid, TouchableOpacity, TouchableOpacityProps } from 'react-native'
 import styled from 'styled-components/native'
+import { setStringAsync } from 'expo-clipboard';
 
 type Props = TouchableOpacityProps & {
     title: string
@@ -15,13 +16,19 @@ export const DetailSection: React.FC<Props> = ({
     onPress,
     ...props
   }) => {
+    const handleLongPress = async () => {
+        await setStringAsync(props.value)
+        if (Platform.Version <= 32) {
+            ToastAndroid.show("Copied", ToastAndroid.SHORT)
+        }
+    };
     return (
         <SectionContainer>
-            <TouchableOpacity onPress={onPress} disabled={props.disabled}>
+            <TouchableOpacity onPress={onPress} onLongPress={Platform.OS === 'android' ? handleLongPress: null} disabled={props.disabled}>
                 <HStack alignItems={'center'}>
                     <VStack>
                         <SectionTitle>{props.title}</SectionTitle>
-                        <SectionValue color={props.color} >{props.value}</SectionValue>
+                        <SectionValue selectable={Platform.OS === 'ios'} color={props.color} >{props.value}</SectionValue>
                     </VStack>
                     {(props.showDisclosure == true) && 
                     <>


### PR DESCRIPTION
## iOS
https://github.com/elijah-wood/Serv-App/assets/460919/cc2e1f74-a383-43dc-982b-4326ead2bdd1


## Android 13
> Starting in Android 13, the system displays a standard visual confirmation when content is added to the clipboard. The new confirmation does the following:
> - Confirms the content was successfully copied.
> - Provides a preview of the copied content.

https://github.com/elijah-wood/Serv-App/assets/460919/40373646-8c8c-4741-9f58-e14f41892405


## Android 12 (or older)
https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications
> In Android 12L (API level 32) and lower, we recommend alerting users when they successfully copy by issuing visual, in-app feedback, using a widget like a Toast or a Snackbar, after copying.

https://github.com/elijah-wood/Serv-App/assets/460919/3f969dfc-83eb-4c2a-a778-8a5c315e5548